### PR TITLE
Update resume.tex

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -117,5 +117,5 @@
       \input{content/skillset.tex}
       \input{content/education.tex}
     \end{rightcolumn}
-  \end{parcol}
+  \end{paracol}
 \end{document}

--- a/resume.tex
+++ b/resume.tex
@@ -9,7 +9,6 @@
   bottom=20mm
 ]{geometry}
 
-\usepackage[none]{hyphenat} % disable hyphenating
 \usepackage{hyperref} % use urls
 \usepackage{xcolor} % use colors
 \usepackage{graphbox} % use graphics
@@ -19,9 +18,7 @@
 \SetWatermarkText{\includegraphics{assets/watermark.eps}}
 \SetWatermarkAngle{0}
 
-% set global justification for text
 \usepackage{ragged2e}
-\RaggedRight
 
 % set text lineheight
 \usepackage{setspace}
@@ -91,31 +88,31 @@
 % set list style
 \usepackage{tasks}
 \settasks{
-  label = •,
+  label = \symbol{8226},
   label-offset = 0em,
-  item-indent = .9em,
-  after-item-skip = -\parskip
+  item-indent = 1.5em
 }
 
 \textColor
 \begin{document}
-%
-  \begin{minipage}[t]{0.60\textwidth}
-    \input{content/projects.tex}
-    \input{content/experience.tex}
-  \end{minipage}
-%
-  \hfill
-%
-  \begin{minipage}[t]{0.35\textwidth}
-    \section*{About}
-    I am Mohsen, but you can call me Bumbleboss; that's my online nickname.
-    Product Designer, Frontend Engineer, and academically a Mechatronics Engineer.
-    Occasionally a gamer and binge-watcher though.
-    \vspace{4.8mm}
-
-    \input{content/skillset.tex}
-    \input{content/education.tex}
-  \end{minipage}
-%
+  \setcolumnwidth{0.65\textwidth,0.35\textwidth}
+  \setlength{\columnsep}{3em}
+  
+  \begin{paracol}{2}
+    \begin{leftcolumn}
+      \input{content/projects.tex}
+      \input{content/experience.tex}
+    \end{leftcolumn}
+    
+    \begin{rightcolumn}
+      \sloppy\RaggedRight
+      \section*{About}
+      I am Mohsen, but you can call me \mbox{Bumbleboss}; that's my online nickname.
+      Product Designer, Frontend Engineer, and academically a Mechatronics Engineer.
+      Occasionally a gamer and binge-watcher though.
+      %
+      \input{content/skillset.tex}
+      \input{content/education.tex}
+    \end{rightcolumn}
+  \end{parcol}
 \end{document}

--- a/resume.tex
+++ b/resume.tex
@@ -9,6 +9,9 @@
   bottom=20mm
 ]{geometry}
 
+\usepackage[protrusion=true, expansion=true]{microtype}
+\usepackage{paracol}
+
 \usepackage{hyperref} % use urls
 \usepackage{xcolor} % use colors
 \usepackage{graphbox} % use graphics


### PR DESCRIPTION
Using a more robust approach with paracol to build the two-column page instead of manually doing it with minipages. Improved typography with hyphenation and text justification in the larger column, making the paragraphs look more solud and complete. Sloppy ragged text for the smaller column allows for hyphenated words but restrict the line-filling as much. The item indentation for the lists is too small resulting in zero space between the two columns when a word has a bad width. Changed it so that it looks symmetric and works visually.

Are you sure that the title should be set in the page header? I don't think it is a good idea unless you really want it to appear on the next pages as well (I don't think that would be good either).

If you have to stick with XeTeX, remove the line with microtype.